### PR TITLE
Invalidation in computeScroll() needs to be delayed

### DIFF
--- a/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
+++ b/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
@@ -1181,6 +1181,7 @@ public class NumberPicker extends LinearLayout {
         if (!mComputeMaxWidth) {
             return;
         }
+        mSelectorWheelPaint.setTextSize(Math.max(mTextSize, mSelectedTextSize));
         int maxTextWidth = 0;
         if (mDisplayedValues == null) {
             float maxDigitWidth = 0;

--- a/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
+++ b/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
@@ -1008,7 +1008,7 @@ public class NumberPicker extends LinearLayout {
         if (scroller.isFinished()) {
             onScrollerFinished(scroller);
         } else {
-            invalidate();
+            postInvalidate();
         }
     }
 


### PR DESCRIPTION
Multiple fixes to the lib:
* Invalidation in computeScroll() needs to be delayed
* Selected/Regular text sizes should be taken into account when measuring max width