### PR TITLE
Accessibility: TalkBack

### DIFF
--- a/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
+++ b/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
@@ -1711,7 +1711,16 @@ public class NumberPicker extends LinearLayout {
             notifyChange(previous, current);
         }
         initializeSelectorWheelIndices();
+        updateAccessibilityDescription();
         invalidate();
+    }
+
+    /**
+     * Updates the accessibility values of the view,
+     * to the currently selected value
+     */
+    private void updateAccessibilityDescription() {
+        this.setContentDescription(String.valueOf(getValue()));
     }
 
     /**

--- a/library/src/main/res/layout/number_picker_with_selector_wheel.xml
+++ b/library/src/main/res/layout/number_picker_with_selector_wheel.xml
@@ -6,6 +6,7 @@
         android:layout_height="wrap_content"
         android:background="@null"
         android:gravity="center"
+        android:importantForAccessibility="no"
         android:hint="@null"
         android:singleLine="true" />
 </merge>


### PR DESCRIPTION
Enable TalkBack accessibility by reading aloud the selected value of the NumberPicker (instead of TalkBack saying e.g. "Disabled edittext, 03" for the first value, and then is unable to say anything for the NumberPicker afterwards)