### PR TITLE
Add underline divider feature

### DIFF
--- a/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
+++ b/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
@@ -119,6 +119,11 @@ public class NumberPicker extends LinearLayout {
     private static final int DEFAULT_DIVIDER_COLOR = 0xFF000000;
 
     /**
+     * The default divider type.
+     */
+    private static final DividerType DEFAULT_DIVIDER_TYPE = DividerType.SIDE_LINES;
+
+    /**
      * The default max value of this widget.
      */
     private static final int DEFAULT_MAX_VALUE = 100;
@@ -535,6 +540,19 @@ public class NumberPicker extends LinearLayout {
     private int mRightDividerRight;
 
     /**
+     * The enum of divider types.
+     */
+    private enum DividerType {
+        SIDE_LINES,
+        UNDERLINE,
+    }
+
+    /**
+     * The type of the divider.
+     */
+    private DividerType mDividerType;
+
+    /**
      * The current scroll state of the number picker.
      */
     private int mScrollState = OnScrollListener.SCROLL_STATE_IDLE;
@@ -736,6 +754,8 @@ public class NumberPicker extends LinearLayout {
                 R.styleable.NumberPicker_np_dividerDistance, defDividerDistance);
         mDividerThickness = attributes.getDimensionPixelSize(
                 R.styleable.NumberPicker_np_dividerThickness, defDividerThickness);
+        mDividerType = DividerType.values()[attributes.getInt(
+                R.styleable.NumberPicker_np_dividerType, DEFAULT_DIVIDER_TYPE.ordinal())];
 
         mOrder = attributes.getInt(R.styleable.NumberPicker_np_order, ASCENDING);
         mOrientation = attributes.getInt(R.styleable.NumberPicker_np_orientation, VERTICAL);
@@ -901,6 +921,7 @@ public class NumberPicker extends LinearLayout {
             if (isHorizontalMode()) {
                 mLeftDividerLeft = (getWidth() - mDividerDistance) / 2 - mDividerThickness;
                 mRightDividerRight = mLeftDividerLeft + dividerDistance;
+                mBottomDividerBottom = getHeight();
             } else {
                 mTopDividerTop = (getHeight() - mDividerDistance) / 2 - mDividerThickness;
                 mBottomDividerBottom = mTopDividerTop + dividerDistance;
@@ -1807,35 +1828,72 @@ public class NumberPicker extends LinearLayout {
 
         // draw the dividers
         if (showSelectorWheel && mDividerDrawable != null) {
-            if (isHorizontalMode()) {
-                final int bottom = getBottom();
+            if (isHorizontalMode())
+                drawHorizontalDividers(canvas);
+            else
+                drawVerticalDividers(canvas);
+        }
+    }
 
+    private void drawHorizontalDividers(Canvas canvas) {
+        switch (mDividerType) {
+            case SIDE_LINES:
+                final int bottom = getBottom();
                 // draw the left divider
                 final int leftOfLeftDivider = mLeftDividerLeft;
                 final int rightOfLeftDivider = leftOfLeftDivider + mDividerThickness;
                 mDividerDrawable.setBounds(leftOfLeftDivider, 0, rightOfLeftDivider, bottom);
                 mDividerDrawable.draw(canvas);
-
                 // draw the right divider
                 final int rightOfRightDivider = mRightDividerRight;
                 final int leftOfRightDivider = rightOfRightDivider - mDividerThickness;
                 mDividerDrawable.setBounds(leftOfRightDivider, 0, rightOfRightDivider, bottom);
                 mDividerDrawable.draw(canvas);
-            } else {
-                final int right = getRight();
+                break;
+            case UNDERLINE:
+                final int leftOfUnderlineDivider = mLeftDividerLeft;
+                final int rightOfUnderlineDivider = mRightDividerRight;
+                final int bottomOfUnderlineDivider = mBottomDividerBottom;
+                final int topOfUnderlineDivider = bottomOfUnderlineDivider - mDividerThickness;
+                mDividerDrawable.setBounds(
+                    leftOfUnderlineDivider,
+                    topOfUnderlineDivider,
+                    rightOfUnderlineDivider,
+                    bottomOfUnderlineDivider
+                );
+                mDividerDrawable.draw(canvas);
+                break;
+        }
+    }
 
+    private void drawVerticalDividers(Canvas canvas) {
+        switch (mDividerType) {
+            case SIDE_LINES:
+                final int right = getRight();
                 // draw the top divider
                 final int topOfTopDivider = mTopDividerTop;
                 final int bottomOfTopDivider = topOfTopDivider + mDividerThickness;
                 mDividerDrawable.setBounds(0, topOfTopDivider, right, bottomOfTopDivider);
                 mDividerDrawable.draw(canvas);
-
                 // draw the bottom divider
                 final int bottomOfBottomDivider = mBottomDividerBottom;
                 final int topOfBottomDivider = bottomOfBottomDivider - mDividerThickness;
                 mDividerDrawable.setBounds(0, topOfBottomDivider, right, bottomOfBottomDivider);
                 mDividerDrawable.draw(canvas);
-            }
+                break;
+            case UNDERLINE:
+                final int leftOfUnderlineDivider = 0;
+                final int rightOfUnderlineDivider = getRight();
+                final int bottomOfUnderlineDivider = mBottomDividerBottom;
+                final int topOfUnderlineDivider = bottomOfUnderlineDivider - mDividerThickness;
+                mDividerDrawable.setBounds(
+                    leftOfUnderlineDivider,
+                    topOfUnderlineDivider,
+                    rightOfUnderlineDivider,
+                    bottomOfUnderlineDivider
+                );
+                mDividerDrawable.draw(canvas);
+                break;
         }
     }
 

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -8,6 +8,10 @@
         <attr name="np_height" format="dimension" />
         <attr name="np_accessibilityDescriptionEnabled" format="boolean" />
         <attr name="np_divider" format="reference" />
+        <attr name="np_dividerType" format="enum">
+            <enum name="side_lines" value="0" />
+            <enum name="underline" value="1" />
+        </attr>
         <attr name="np_dividerColor" format="color" />
         <attr name="np_dividerDistance" format="dimension" />
         <attr name="np_dividerThickness" format="dimension" />

--- a/sample/src/main/res/layout/content_main.xml
+++ b/sample/src/main/res/layout/content_main.xml
@@ -17,7 +17,8 @@
     <com.shawnlin.numberpicker.NumberPicker
         android:id="@+id/number_picker"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content"
+        app:np_dividerType="underline" />
 
     <com.shawnlin.numberpicker.NumberPicker
         android:id="@+id/horizontal_number_picker"
@@ -39,6 +40,7 @@
         app:np_textSize="@dimen/text_size"
         app:np_typeface="@string/roboto_light"
         app:np_fadingEdgeEnabled="false"
-        app:np_wrapSelectorWheel="true" />
+        app:np_wrapSelectorWheel="true"
+        app:np_dividerType="underline" />
 
 </LinearLayout>


### PR DESCRIPTION
### Problem
I got a task to implement underline divider ([design screenshot](https://drive.google.com/file/d/1OClhIxTIZwlM59z-vRNWdalL421ABkSC/view?usp=sharing)). I have tried to use `np_selectedTextUnderline` attribute but it doesn't work correctly because it underlines selected text, not cell ([problem demonstration](https://drive.google.com/file/d/151RNoJvqwpktzBd_1VOcvDBW83vEyg7o/view?usp=sharing)).
### Solution
There is a new `np_dividerType` attribute to use. Now `NumberPicker` supports two types of dividers: side lines (default) and underline, packed in `DividerType` enum so we can add new types easily. That's what I've got ([result demonstration](https://drive.google.com/file/d/1sOwOJb6HKqe_wUeEow-7Lno5vOuD2EML/view?usp=sharing)).

@ShawnLin013, thanks a lot for your work. You saved my time. I hope this feature will improve your project and engage new developers.