### PR TITLE
Add align and sidePadding attributes

### DIFF
--- a/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
+++ b/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
@@ -149,6 +149,11 @@ public class NumberPicker extends LinearLayout {
     private static final int DEFAULT_TEXT_ALIGN = CENTER;
 
     /**
+     * The default content alignment.
+     */
+    private static final int DEFAULT_ALIGN = CENTER;
+
+    /**
      * The default color of text.
      */
     private static final int DEFAULT_TEXT_COLOR = 0xFF000000;
@@ -615,6 +620,16 @@ public class NumberPicker extends LinearLayout {
     private ViewConfiguration mViewConfiguration;
 
     /**
+     * The content alignment.
+     */
+    private int mAlign = DEFAULT_ALIGN;
+
+    /**
+     * The padding applied to the content when it's not centered (align is "left" or "right").
+     */
+    private int mSidePadding = 0;
+
+    /**
      * Interface to listen for changes of the current value.
      */
     public interface OnValueChangeListener {
@@ -793,6 +808,9 @@ public class NumberPicker extends LinearLayout {
                 R.styleable.NumberPicker_np_hideWheelUntilFocused, false);
         mAccessibilityDescriptionEnabled = attributes.getBoolean(
                 R.styleable.NumberPicker_np_accessibilityDescriptionEnabled, true);
+        mAlign = attributes.getInt(R.styleable.NumberPicker_np_align, mAlign);
+        mSidePadding = attributes.getDimensionPixelSize(
+                R.styleable.NumberPicker_np_sidePadding, mSidePadding);
 
         // By default Linearlayout that we extend is not drawn. This is
         // its draw() method is not called but dispatchDraw() is called
@@ -1751,7 +1769,14 @@ public class NumberPicker extends LinearLayout {
                 canvas.clipRect(mLeftDividerLeft, 0, mRightDividerRight, getBottom());
             }
         } else {
-            x = (getRight() - getLeft()) / 2;
+            if (mAlign == LEFT) {
+                x = getLeft() + mSidePadding;
+            } else if (mAlign == RIGHT) {
+                x = getRight() - getMaxTextSize() - mSidePadding;
+            } else {
+                x = (getRight() - getLeft()) / 2f;
+            }
+
             y = mCurrentScrollOffset;
             if (mRealWheelItemCount < DEFAULT_WHEEL_ITEM_COUNT) {
                 canvas.clipRect(0, mTopDividerTop, getRight(), mBottomDividerBottom);

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -51,5 +51,11 @@
         <attr name="np_value" format="integer" />
         <attr name="np_wheelItemCount" format="integer" />
         <attr name="np_wrapSelectorWheel" format="boolean" />
+        <attr name="np_align" format="enum">
+            <enum name="right" value="0" />
+            <enum name="center" value="1" />
+            <enum name="left" value="2" />
+        </attr>
+        <attr name="np_sidePadding" format="dimension" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
Hi! I did a few changes in the project to accomplish some layout characteristics that I couldn't do using only the options currently available in the component. Since it may be something useful to somebody else, I'm creating this PR to contribute.

The layout had the elements of the picker aligned to the left but the text of the elements still centered accordingly to their width. As in the following image:

![picker](https://user-images.githubusercontent.com/6335577/86411041-570df100-bc92-11ea-950c-4505d1334504.png)

As you can see, the element of value 1 is aligned with the center of the one of value 100.

To accomplish this, I created two new optional attributes: `np_align` and `np_sidePadding`. Both work only when the orientation is vertical. The `np_align` attribute accepts three different values: `left`, `center`, and `right`. As suggested by itself, the `align` attribute makes the component align its elements to the center (current and default behavior,) to the left, or to the right of the container. The `np_sidePadding` (default: 0) is applied only when the `align` is not set to `center` because it would not be useful in this case. When defined, `np_sidePadding` adds a space between the side of the alignment in the container and the element.

Please, let me know if it's not interesting for this library or if there is any change that must be done before merging.