### PR TITLE
Add ability to update the spacing between items

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ add `xmlns:app="http://schemas.android.com/apk/res-auto"`
 |np_fadingEdgeStrength|The strength of fading edge while drawing the selector.|
 |np_formatter|The formatter of the numbers.|
 |np_hideWheelUntilFocused|Flag whether the selector wheel should hidden until the picker has focus.|
-|mItemSpacing|Amount of space between items.|
+|np_itemSpacing|Amount of space between items.|
 |np_lineSpacingMultiplier|The line spacing multiplier for the multiple lines.|
 |np_max|The max value of this widget.|
 |np_maxFlingVelocityCoefficient|The coefficient to adjust (divide) the max fling velocity.|

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ add `xmlns:app="http://schemas.android.com/apk/res-auto"`
 |np_fadingEdgeStrength|The strength of fading edge while drawing the selector.|
 |np_formatter|The formatter of the numbers.|
 |np_hideWheelUntilFocused|Flag whether the selector wheel should hidden until the picker has focus.|
+|mItemSpacing|Amount of space between items.|
 |np_lineSpacingMultiplier|The line spacing multiplier for the multiple lines.|
 |np_max|The max value of this widget.|
 |np_maxFlingVelocityCoefficient|The coefficient to adjust (divide) the max fling velocity.|

--- a/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
+++ b/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
@@ -641,6 +641,11 @@ public class NumberPicker extends LinearLayout {
     }
 
     /**
+     * The amount of space between items.
+     */
+    private int mItemSpacing = 0;
+
+    /**
      * Interface to listen for the picker scroll state.
      */
     public interface OnScrollListener {
@@ -723,10 +728,10 @@ public class NumberPicker extends LinearLayout {
         mNumberFormatter = NumberFormat.getInstance();
 
         final TypedArray attributes = context.obtainStyledAttributes(attrs,
-                R.styleable.NumberPicker, defStyle, 0);
+            R.styleable.NumberPicker, defStyle, 0);
 
         final Drawable selectionDivider = attributes.getDrawable(
-                R.styleable.NumberPicker_np_divider);
+            R.styleable.NumberPicker_np_divider);
         if (selectionDivider != null) {
             selectionDivider.setCallback(this);
             if (selectionDivider.isStateful()) {
@@ -735,30 +740,30 @@ public class NumberPicker extends LinearLayout {
             mDividerDrawable = selectionDivider;
         } else {
             mDividerColor = attributes.getColor(R.styleable.NumberPicker_np_dividerColor,
-                    mDividerColor);
+                mDividerColor);
             setDividerColor(mDividerColor);
         }
 
         final DisplayMetrics displayMetrics = getResources().getDisplayMetrics();
         final int defDividerDistance = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,
-                UNSCALED_DEFAULT_DIVIDER_DISTANCE, displayMetrics);
+            UNSCALED_DEFAULT_DIVIDER_DISTANCE, displayMetrics);
         final int defDividerThickness = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,
-                UNSCALED_DEFAULT_DIVIDER_THICKNESS, displayMetrics);
+            UNSCALED_DEFAULT_DIVIDER_THICKNESS, displayMetrics);
         mDividerDistance = attributes.getDimensionPixelSize(
-                R.styleable.NumberPicker_np_dividerDistance, defDividerDistance);
+            R.styleable.NumberPicker_np_dividerDistance, defDividerDistance);
         mDividerLength = attributes.getDimensionPixelSize(
-                R.styleable.NumberPicker_np_dividerLength, 0);
+            R.styleable.NumberPicker_np_dividerLength, 0);
         mDividerThickness = attributes.getDimensionPixelSize(
-                R.styleable.NumberPicker_np_dividerThickness, defDividerThickness);
+            R.styleable.NumberPicker_np_dividerThickness, defDividerThickness);
         mDividerType = attributes.getInt(R.styleable.NumberPicker_np_dividerType, SIDE_LINES);
 
         mOrder = attributes.getInt(R.styleable.NumberPicker_np_order, ASCENDING);
         mOrientation = attributes.getInt(R.styleable.NumberPicker_np_orientation, VERTICAL);
 
         final float width = attributes.getDimensionPixelSize(R.styleable.NumberPicker_np_width,
-                SIZE_UNSPECIFIED);
+            SIZE_UNSPECIFIED);
         final float height = attributes.getDimensionPixelSize(R.styleable.NumberPicker_np_height,
-                SIZE_UNSPECIFIED);
+            SIZE_UNSPECIFIED);
 
         setWidthAndHeight();
 
@@ -769,45 +774,47 @@ public class NumberPicker extends LinearLayout {
         mMinValue = attributes.getInt(R.styleable.NumberPicker_np_min, mMinValue);
 
         mSelectedTextAlign = attributes.getInt(R.styleable.NumberPicker_np_selectedTextAlign,
-                mSelectedTextAlign);
+            mSelectedTextAlign);
         mSelectedTextColor = attributes.getColor(R.styleable.NumberPicker_np_selectedTextColor,
-                mSelectedTextColor);
+            mSelectedTextColor);
         mSelectedTextSize = attributes.getDimension(R.styleable.NumberPicker_np_selectedTextSize,
-                spToPx(mSelectedTextSize));
+            spToPx(mSelectedTextSize));
         mSelectedTextStrikeThru = attributes.getBoolean(
-                R.styleable.NumberPicker_np_selectedTextStrikeThru, mSelectedTextStrikeThru);
+            R.styleable.NumberPicker_np_selectedTextStrikeThru, mSelectedTextStrikeThru);
         mSelectedTextUnderline = attributes.getBoolean(
-                R.styleable.NumberPicker_np_selectedTextUnderline, mSelectedTextUnderline);
+            R.styleable.NumberPicker_np_selectedTextUnderline, mSelectedTextUnderline);
         mSelectedTypeface = Typeface.create(attributes.getString(
-                R.styleable.NumberPicker_np_selectedTypeface), Typeface.NORMAL);
+            R.styleable.NumberPicker_np_selectedTypeface), Typeface.NORMAL);
         mTextAlign = attributes.getInt(R.styleable.NumberPicker_np_textAlign, mTextAlign);
         mTextColor = attributes.getColor(R.styleable.NumberPicker_np_textColor, mTextColor);
         mTextSize = attributes.getDimension(R.styleable.NumberPicker_np_textSize,
-                spToPx(mTextSize));
+            spToPx(mTextSize));
         mTextStrikeThru = attributes.getBoolean(
-                R.styleable.NumberPicker_np_textStrikeThru, mTextStrikeThru);
+            R.styleable.NumberPicker_np_textStrikeThru, mTextStrikeThru);
         mTextUnderline = attributes.getBoolean(
-                R.styleable.NumberPicker_np_textUnderline, mTextUnderline);
+            R.styleable.NumberPicker_np_textUnderline, mTextUnderline);
         mTypeface = Typeface.create(attributes.getString(R.styleable.NumberPicker_np_typeface),
-                Typeface.NORMAL);
+            Typeface.NORMAL);
         mFormatter = stringToFormatter(attributes.getString(R.styleable.NumberPicker_np_formatter));
         mFadingEdgeEnabled = attributes.getBoolean(R.styleable.NumberPicker_np_fadingEdgeEnabled,
-                mFadingEdgeEnabled);
+            mFadingEdgeEnabled);
         mFadingEdgeStrength = attributes.getFloat(R.styleable.NumberPicker_np_fadingEdgeStrength,
-                mFadingEdgeStrength);
+            mFadingEdgeStrength);
         mScrollerEnabled = attributes.getBoolean(R.styleable.NumberPicker_np_scrollerEnabled,
-                mScrollerEnabled);
+            mScrollerEnabled);
         mWheelItemCount = attributes.getInt(R.styleable.NumberPicker_np_wheelItemCount,
-                mWheelItemCount);
+            mWheelItemCount);
         mLineSpacingMultiplier = attributes.getFloat(
-                R.styleable.NumberPicker_np_lineSpacingMultiplier, mLineSpacingMultiplier);
+            R.styleable.NumberPicker_np_lineSpacingMultiplier, mLineSpacingMultiplier);
         mMaxFlingVelocityCoefficient = attributes.getInt(
-                R.styleable.NumberPicker_np_maxFlingVelocityCoefficient,
-                mMaxFlingVelocityCoefficient);
+            R.styleable.NumberPicker_np_maxFlingVelocityCoefficient,
+            mMaxFlingVelocityCoefficient);
         mHideWheelUntilFocused = attributes.getBoolean(
-                R.styleable.NumberPicker_np_hideWheelUntilFocused, false);
+            R.styleable.NumberPicker_np_hideWheelUntilFocused, false);
         mAccessibilityDescriptionEnabled = attributes.getBoolean(
-                R.styleable.NumberPicker_np_accessibilityDescriptionEnabled, true);
+            R.styleable.NumberPicker_np_accessibilityDescriptionEnabled, true);
+        mItemSpacing = attributes.getDimensionPixelSize(
+            R.styleable.NumberPicker_np_itemSpacing, 0);
 
         // By default LinearLayout that we extend is not drawn. This is
         // its draw() method is not called but dispatchDraw() is called
@@ -817,7 +824,7 @@ public class NumberPicker extends LinearLayout {
         setWillNotDraw(false);
 
         LayoutInflater inflater = (LayoutInflater) context.getSystemService(
-                Context.LAYOUT_INFLATER_SERVICE);
+            Context.LAYOUT_INFLATER_SERVICE);
         inflater.inflate(R.layout.number_picker_material, this, true);
 
         // input text
@@ -848,7 +855,7 @@ public class NumberPicker extends LinearLayout {
         setWheelItemCount(mWheelItemCount);
 
         mWrapSelectorWheel = attributes.getBoolean(R.styleable.NumberPicker_np_wrapSelectorWheel,
-                mWrapSelectorWheel);
+            mWrapSelectorWheel);
         setWrapSelectorWheel(mWrapSelectorWheel);
 
         if (width != SIZE_UNSPECIFIED && height != SIZE_UNSPECIFIED) {
@@ -869,7 +876,7 @@ public class NumberPicker extends LinearLayout {
         mTouchSlop = mViewConfiguration.getScaledTouchSlop();
         mMinimumFlingVelocity = mViewConfiguration.getScaledMinimumFlingVelocity();
         mMaximumFlingVelocity = mViewConfiguration.getScaledMaximumFlingVelocity()
-                / mMaxFlingVelocityCoefficient;
+            / mMaxFlingVelocityCoefficient;
 
         // create the fling and adjust scrollers
         mFlingScroller = new Scroller(context, null, true);
@@ -934,9 +941,9 @@ public class NumberPicker extends LinearLayout {
         super.onMeasure(newWidthMeasureSpec, newHeightMeasureSpec);
         // Flag if we are measured with width or height less than the respective min.
         final int widthSize = resolveSizeAndStateRespectingMinSize(mMinWidth, getMeasuredWidth(),
-                widthMeasureSpec);
+            widthMeasureSpec);
         final int heightSize = resolveSizeAndStateRespectingMinSize(mMinHeight, getMeasuredHeight(),
-                heightMeasureSpec);
+            heightMeasureSpec);
         setMeasuredDimension(widthSize, heightSize);
     }
 
@@ -1013,7 +1020,7 @@ public class NumberPicker extends LinearLayout {
                 mAdjustScroller.forceFinished(true);
                 onScrollerFinished(mAdjustScroller);
             } else if (mLastDownEventX >= mLeftDividerLeft
-                    && mLastDownEventX <= mRightDividerRight) {
+                && mLastDownEventX <= mRightDividerRight) {
                 if (mOnClickListener != null) {
                     mOnClickListener.onClick(this);
                 }
@@ -1032,7 +1039,7 @@ public class NumberPicker extends LinearLayout {
                 mFlingScroller.forceFinished(true);
                 mAdjustScroller.forceFinished(true);
             } else if (mLastDownEventY >= mTopDividerTop
-                    && mLastDownEventY <= mBottomDividerBottom) {
+                && mLastDownEventY <= mBottomDividerBottom) {
                 if (mOnClickListener != null) {
                     mOnClickListener.onClick(this);
                 }
@@ -1105,7 +1112,7 @@ public class NumberPicker extends LinearLayout {
                         int deltaMoveX = (int) Math.abs(eventX - mLastDownEventX);
                         if (deltaMoveX <= mTouchSlop) {
                             int selectorIndexOffset = (eventX / mSelectorElementSize)
-                                    - mWheelMiddleItemIndex;
+                                - mWheelMiddleItemIndex;
                             if (selectorIndexOffset > 0) {
                                 changeValueByOne(true);
                             } else if (selectorIndexOffset < 0) {
@@ -1128,7 +1135,7 @@ public class NumberPicker extends LinearLayout {
                         int deltaMoveY = (int) Math.abs(eventY - mLastDownEventY);
                         if (deltaMoveY <= mTouchSlop) {
                             int selectorIndexOffset = (eventY / mSelectorElementSize)
-                                    - mWheelMiddleItemIndex;
+                                - mWheelMiddleItemIndex;
                             if (selectorIndexOffset > 0) {
                                 changeValueByOne(true);
                             } else if (selectorIndexOffset < 0) {
@@ -1175,7 +1182,7 @@ public class NumberPicker extends LinearLayout {
                 switch (event.getAction()) {
                     case KeyEvent.ACTION_DOWN:
                         if (mWrapSelectorWheel || ((keyCode == KeyEvent.KEYCODE_DPAD_DOWN)
-                                ? getValue() < getMaxValue() : getValue() > getMinValue())) {
+                            ? getValue() < getMaxValue() : getValue() > getMinValue())) {
                             requestFocus();
                             mLastHandledDownDpadKeyCode = keyCode;
                             removeAllCallbacks();
@@ -1261,23 +1268,23 @@ public class NumberPicker extends LinearLayout {
         if (isHorizontalMode()) {
             if (isAscendingOrder()) {
                 if (!mWrapSelectorWheel && x > 0
-                        && selectorIndices[mWheelMiddleItemIndex] <= mMinValue) {
+                    && selectorIndices[mWheelMiddleItemIndex] <= mMinValue) {
                     mCurrentScrollOffset = mInitialScrollOffset;
                     return;
                 }
                 if (!mWrapSelectorWheel && x < 0
-                        && selectorIndices[mWheelMiddleItemIndex] >= mMaxValue) {
+                    && selectorIndices[mWheelMiddleItemIndex] >= mMaxValue) {
                     mCurrentScrollOffset = mInitialScrollOffset;
                     return;
                 }
             } else {
                 if (!mWrapSelectorWheel && x > 0
-                        && selectorIndices[mWheelMiddleItemIndex] >= mMaxValue) {
+                    && selectorIndices[mWheelMiddleItemIndex] >= mMaxValue) {
                     mCurrentScrollOffset = mInitialScrollOffset;
                     return;
                 }
                 if (!mWrapSelectorWheel && x < 0
-                        && selectorIndices[mWheelMiddleItemIndex] <= mMinValue) {
+                    && selectorIndices[mWheelMiddleItemIndex] <= mMinValue) {
                     mCurrentScrollOffset = mInitialScrollOffset;
                     return;
                 }
@@ -1287,23 +1294,23 @@ public class NumberPicker extends LinearLayout {
         } else {
             if (isAscendingOrder()) {
                 if (!mWrapSelectorWheel && y > 0
-                        && selectorIndices[mWheelMiddleItemIndex] <= mMinValue) {
+                    && selectorIndices[mWheelMiddleItemIndex] <= mMinValue) {
                     mCurrentScrollOffset = mInitialScrollOffset;
                     return;
                 }
                 if (!mWrapSelectorWheel && y < 0
-                        && selectorIndices[mWheelMiddleItemIndex] >= mMaxValue) {
+                    && selectorIndices[mWheelMiddleItemIndex] >= mMaxValue) {
                     mCurrentScrollOffset = mInitialScrollOffset;
                     return;
                 }
             } else {
                 if (!mWrapSelectorWheel && y > 0
-                        && selectorIndices[mWheelMiddleItemIndex] >= mMaxValue) {
+                    && selectorIndices[mWheelMiddleItemIndex] >= mMaxValue) {
                     mCurrentScrollOffset = mInitialScrollOffset;
                     return;
                 }
                 if (!mWrapSelectorWheel && y < 0
-                        && selectorIndices[mWheelMiddleItemIndex] <= mMinValue) {
+                    && selectorIndices[mWheelMiddleItemIndex] <= mMinValue) {
                     mCurrentScrollOffset = mInitialScrollOffset;
                     return;
                 }
@@ -1689,7 +1696,7 @@ public class NumberPicker extends LinearLayout {
         if (mDisplayedValues != null) {
             // Allow text entry rather than strictly numeric entry.
             mSelectedText.setRawInputType(InputType.TYPE_TEXT_FLAG_MULTI_LINE
-                    | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
+                | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
         } else {
             mSelectedText.setRawInputType(InputType.TYPE_CLASS_NUMBER);
         }
@@ -1733,7 +1740,7 @@ public class NumberPicker extends LinearLayout {
     protected void drawableStateChanged() {
         super.drawableStateChanged();
         if (mDividerDrawable != null && mDividerDrawable.isStateful()
-                && mDividerDrawable.setState(getDrawableState())) {
+            && mDividerDrawable.setState(getDrawableState())) {
             invalidateDrawable(mDividerDrawable);
         }
     }
@@ -1788,7 +1795,7 @@ public class NumberPicker extends LinearLayout {
             }
 
             int selectorIndex = selectorIndices[isAscendingOrder()
-                    ? i : selectorIndices.length - i - 1];
+                ? i : selectorIndices.length - i - 1];
             String scrollSelectorValue = mSelectorIndexToStringCache.get(selectorIndex);
             if (scrollSelectorValue == null) {
                 continue;
@@ -1799,12 +1806,32 @@ public class NumberPicker extends LinearLayout {
             // IME he may see a dimmed version of the old value intermixed
             // with the new one.
             if ((showSelectorWheel && i != mWheelMiddleItemIndex)
-                    || (i == mWheelMiddleItemIndex && mSelectedText.getVisibility() != VISIBLE)) {
+                || (i == mWheelMiddleItemIndex && mSelectedText.getVisibility() != VISIBLE)) {
                 float textY = y;
                 if (!isHorizontalMode()) {
                     textY += getPaintCenterY(mSelectorWheelPaint.getFontMetrics());
                 }
-                drawText(scrollSelectorValue, x, textY, mSelectorWheelPaint, canvas);
+
+                int xOffset = 0;
+                int yOffset = 0;
+
+                if (i != mWheelMiddleItemIndex) {
+                    if (isHorizontalMode()) {
+                        if (i > mWheelMiddleItemIndex){
+                            xOffset = mItemSpacing;
+                        } else {
+                            xOffset = -mItemSpacing;
+                        }
+                    } else {
+                        if (i > mWheelMiddleItemIndex){
+                            yOffset = mItemSpacing;
+                        } else {
+                            yOffset = -mItemSpacing;
+                        }
+                    }
+                }
+
+                drawText(scrollSelectorValue, x + xOffset, textY + yOffset, mSelectorWheelPaint, canvas);
             }
 
             if (isHorizontalMode()) {
@@ -1862,10 +1889,10 @@ public class NumberPicker extends LinearLayout {
                 final int bottomOfUnderlineDivider = mBottomDividerBottom;
                 final int topOfUnderlineDivider = bottomOfUnderlineDivider - mDividerThickness;
                 mDividerDrawable.setBounds(
-                        left,
-                        topOfUnderlineDivider,
-                        right,
-                        bottomOfUnderlineDivider
+                    left,
+                    topOfUnderlineDivider ,
+                    right,
+                    bottomOfUnderlineDivider
                 );
                 mDividerDrawable.draw(canvas);
                 break;
@@ -1887,26 +1914,26 @@ public class NumberPicker extends LinearLayout {
                 // draw the top divider
                 final int topOfTopDivider = mTopDividerTop;
                 final int bottomOfTopDivider = topOfTopDivider + mDividerThickness;
-                mDividerDrawable.setBounds(left, topOfTopDivider, right, bottomOfTopDivider);
+                mDividerDrawable.setBounds(left, topOfTopDivider, right, bottomOfTopDivider );
                 mDividerDrawable.draw(canvas);
                 // draw the bottom divider
                 final int bottomOfBottomDivider = mBottomDividerBottom;
                 final int topOfBottomDivider = bottomOfBottomDivider - mDividerThickness;
                 mDividerDrawable.setBounds(
-                        left,
-                        topOfBottomDivider,
-                        right,
-                        bottomOfBottomDivider);
+                    left,
+                    topOfBottomDivider,
+                    right,
+                    bottomOfBottomDivider);
                 mDividerDrawable.draw(canvas);
                 break;
             case UNDERLINE:
                 final int bottomOfUnderlineDivider = mBottomDividerBottom;
                 final int topOfUnderlineDivider = bottomOfUnderlineDivider - mDividerThickness;
                 mDividerDrawable.setBounds(
-                        left,
-                        topOfUnderlineDivider,
-                        right,
-                        bottomOfUnderlineDivider
+                    left,
+                    topOfUnderlineDivider,
+                    right,
+                    bottomOfUnderlineDivider
                 );
                 mDividerDrawable.draw(canvas);
                 break;
@@ -1917,7 +1944,7 @@ public class NumberPicker extends LinearLayout {
         if (text.contains("\n")) {
             final String[] lines = text.split("\n");
             final float height = Math.abs(paint.descent() + paint.ascent())
-                    * mLineSpacingMultiplier;
+                * mLineSpacingMultiplier;
             final float diff = (lines.length - 1) * height / 2;
             y -= diff;
             for (String line : lines) {
@@ -2304,7 +2331,7 @@ public class NumberPicker extends LinearLayout {
          * number.
          */
         String text = (mDisplayedValues == null) ? formatNumber(mValue)
-                : mDisplayedValues[mValue - mMinValue];
+            : mDisplayedValues[mValue - mMinValue];
         if (TextUtils.isEmpty(text)) {
             return;
         }
@@ -2420,25 +2447,25 @@ public class NumberPicker extends LinearLayout {
      * The numbers accepted by the input text's {@link Filter}
      */
     private static final char[] DIGIT_CHARACTERS = new char[]{
-            // Latin digits are the common case
-            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-            // Arabic-Indic
-            '\u0660', '\u0661', '\u0662', '\u0663', '\u0664',
-            '\u0665', '\u0666', '\u0667', '\u0668', '\u0669',
-            // Extended Arabic-Indic
-            '\u06f0', '\u06f1', '\u06f2', '\u06f3', '\u06f4',
-            '\u06f5', '\u06f6', '\u06f7', '\u06f8', '\u06f9',
-            // Hindi and Marathi (Devanagari script)
-            '\u0966', '\u0967', '\u0968', '\u0969', '\u096a',
-            '\u096b', '\u096c', '\u096d', '\u096e', '\u096f',
-            // Bengali
-            '\u09e6', '\u09e7', '\u09e8', '\u09e9', '\u09ea',
-            '\u09eb', '\u09ec', '\u09ed', '\u09ee', '\u09ef',
-            // Kannada
-            '\u0ce6', '\u0ce7', '\u0ce8', '\u0ce9', '\u0cea',
-            '\u0ceb', '\u0cec', '\u0ced', '\u0cee', '\u0cef',
-            // Negative
-            '-'
+        // Latin digits are the common case
+        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+        // Arabic-Indic
+        '\u0660', '\u0661', '\u0662', '\u0663', '\u0664',
+        '\u0665', '\u0666', '\u0667', '\u0668', '\u0669',
+        // Extended Arabic-Indic
+        '\u06f0', '\u06f1', '\u06f2', '\u06f3', '\u06f4',
+        '\u06f5', '\u06f6', '\u06f7', '\u06f8', '\u06f9',
+        // Hindi and Marathi (Devanagari script)
+        '\u0966', '\u0967', '\u0968', '\u0969', '\u096a',
+        '\u096b', '\u096c', '\u096d', '\u096e', '\u096f',
+        // Bengali
+        '\u09e6', '\u09e7', '\u09e8', '\u09e9', '\u09ea',
+        '\u09eb', '\u09ec', '\u09ed', '\u09ee', '\u09ef',
+        // Kannada
+        '\u0ce6', '\u0ce7', '\u0ce8', '\u0ce9', '\u0cea',
+        '\u0ceb', '\u0cec', '\u0ced', '\u0cee', '\u0cef',
+        // Negative
+        '-'
     };
 
     /**
@@ -2473,7 +2500,7 @@ public class NumberPicker extends LinearLayout {
                 }
 
                 String result = String.valueOf(dest.subSequence(0, dstart)) + filtered
-                        + dest.subSequence(dend, dest.length());
+                    + dest.subSequence(dend, dest.length());
 
                 if ("".equals(result)) {
                     return result;
@@ -2498,7 +2525,7 @@ public class NumberPicker extends LinearLayout {
                     return "";
                 }
                 String result = String.valueOf(dest.subSequence(0, dstart)) + filtered
-                        + dest.subSequence(dend, dest.length());
+                    + dest.subSequence(dend, dest.length());
                 String str = String.valueOf(result).toLowerCase();
                 for (String val : mDisplayedValues) {
                     String valLowerCase = val.toLowerCase();
@@ -2609,7 +2636,7 @@ public class NumberPicker extends LinearLayout {
 
     private float spToPx(float sp) {
         return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, sp,
-                getResources().getDisplayMetrics());
+            getResources().getDisplayMetrics());
     }
 
     private float pxToSp(float px) {
@@ -2853,7 +2880,11 @@ public class NumberPicker extends LinearLayout {
     public void setMaxFlingVelocityCoefficient(int coefficient) {
         mMaxFlingVelocityCoefficient = coefficient;
         mMaximumFlingVelocity = mViewConfiguration.getScaledMaximumFlingVelocity()
-                / mMaxFlingVelocityCoefficient;
+            / mMaxFlingVelocityCoefficient;
+    }
+
+    public void setItemSpacing(int itemSpacing) {
+        mItemSpacing = itemSpacing;
     }
 
     public boolean isHorizontalMode() {

--- a/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
+++ b/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
@@ -1816,13 +1816,13 @@ public class NumberPicker extends LinearLayout {
 
                 if (i != mWheelMiddleItemIndex) {
                     if (isHorizontalMode()) {
-                        if (i > mWheelMiddleItemIndex){
+                        if (i > mWheelMiddleItemIndex) {
                             xOffset = mItemSpacing;
                         } else {
                             xOffset = -mItemSpacing;
                         }
                     } else {
-                        if (i > mWheelMiddleItemIndex){
+                        if (i > mWheelMiddleItemIndex) {
                             yOffset = mItemSpacing;
                         } else {
                             yOffset = -mItemSpacing;

--- a/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
+++ b/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
@@ -728,10 +728,10 @@ public class NumberPicker extends LinearLayout {
         mNumberFormatter = NumberFormat.getInstance();
 
         final TypedArray attributes = context.obtainStyledAttributes(attrs,
-            R.styleable.NumberPicker, defStyle, 0);
+                R.styleable.NumberPicker, defStyle, 0);
 
         final Drawable selectionDivider = attributes.getDrawable(
-            R.styleable.NumberPicker_np_divider);
+                R.styleable.NumberPicker_np_divider);
         if (selectionDivider != null) {
             selectionDivider.setCallback(this);
             if (selectionDivider.isStateful()) {
@@ -740,30 +740,30 @@ public class NumberPicker extends LinearLayout {
             mDividerDrawable = selectionDivider;
         } else {
             mDividerColor = attributes.getColor(R.styleable.NumberPicker_np_dividerColor,
-                mDividerColor);
+                    mDividerColor);
             setDividerColor(mDividerColor);
         }
 
         final DisplayMetrics displayMetrics = getResources().getDisplayMetrics();
         final int defDividerDistance = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,
-            UNSCALED_DEFAULT_DIVIDER_DISTANCE, displayMetrics);
+                UNSCALED_DEFAULT_DIVIDER_DISTANCE, displayMetrics);
         final int defDividerThickness = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,
-            UNSCALED_DEFAULT_DIVIDER_THICKNESS, displayMetrics);
+                UNSCALED_DEFAULT_DIVIDER_THICKNESS, displayMetrics);
         mDividerDistance = attributes.getDimensionPixelSize(
-            R.styleable.NumberPicker_np_dividerDistance, defDividerDistance);
+                R.styleable.NumberPicker_np_dividerDistance, defDividerDistance);
         mDividerLength = attributes.getDimensionPixelSize(
-            R.styleable.NumberPicker_np_dividerLength, 0);
+                R.styleable.NumberPicker_np_dividerLength, 0);
         mDividerThickness = attributes.getDimensionPixelSize(
-            R.styleable.NumberPicker_np_dividerThickness, defDividerThickness);
+                R.styleable.NumberPicker_np_dividerThickness, defDividerThickness);
         mDividerType = attributes.getInt(R.styleable.NumberPicker_np_dividerType, SIDE_LINES);
 
         mOrder = attributes.getInt(R.styleable.NumberPicker_np_order, ASCENDING);
         mOrientation = attributes.getInt(R.styleable.NumberPicker_np_orientation, VERTICAL);
 
         final float width = attributes.getDimensionPixelSize(R.styleable.NumberPicker_np_width,
-            SIZE_UNSPECIFIED);
+                SIZE_UNSPECIFIED);
         final float height = attributes.getDimensionPixelSize(R.styleable.NumberPicker_np_height,
-            SIZE_UNSPECIFIED);
+                SIZE_UNSPECIFIED);
 
         setWidthAndHeight();
 
@@ -774,48 +774,47 @@ public class NumberPicker extends LinearLayout {
         mMinValue = attributes.getInt(R.styleable.NumberPicker_np_min, mMinValue);
 
         mSelectedTextAlign = attributes.getInt(R.styleable.NumberPicker_np_selectedTextAlign,
-            mSelectedTextAlign);
+                mSelectedTextAlign);
         mSelectedTextColor = attributes.getColor(R.styleable.NumberPicker_np_selectedTextColor,
-            mSelectedTextColor);
+                mSelectedTextColor);
         mSelectedTextSize = attributes.getDimension(R.styleable.NumberPicker_np_selectedTextSize,
-            spToPx(mSelectedTextSize));
+                spToPx(mSelectedTextSize));
         mSelectedTextStrikeThru = attributes.getBoolean(
-            R.styleable.NumberPicker_np_selectedTextStrikeThru, mSelectedTextStrikeThru);
+                R.styleable.NumberPicker_np_selectedTextStrikeThru, mSelectedTextStrikeThru);
         mSelectedTextUnderline = attributes.getBoolean(
-            R.styleable.NumberPicker_np_selectedTextUnderline, mSelectedTextUnderline);
+                R.styleable.NumberPicker_np_selectedTextUnderline, mSelectedTextUnderline);
         mSelectedTypeface = Typeface.create(attributes.getString(
-            R.styleable.NumberPicker_np_selectedTypeface), Typeface.NORMAL);
+                R.styleable.NumberPicker_np_selectedTypeface), Typeface.NORMAL);
         mTextAlign = attributes.getInt(R.styleable.NumberPicker_np_textAlign, mTextAlign);
         mTextColor = attributes.getColor(R.styleable.NumberPicker_np_textColor, mTextColor);
         mTextSize = attributes.getDimension(R.styleable.NumberPicker_np_textSize,
-            spToPx(mTextSize));
+                spToPx(mTextSize));
         mTextStrikeThru = attributes.getBoolean(
-            R.styleable.NumberPicker_np_textStrikeThru, mTextStrikeThru);
+                R.styleable.NumberPicker_np_textStrikeThru, mTextStrikeThru);
         mTextUnderline = attributes.getBoolean(
-            R.styleable.NumberPicker_np_textUnderline, mTextUnderline);
+                R.styleable.NumberPicker_np_textUnderline, mTextUnderline);
         mTypeface = Typeface.create(attributes.getString(R.styleable.NumberPicker_np_typeface),
-            Typeface.NORMAL);
+                Typeface.NORMAL);
         mFormatter = stringToFormatter(attributes.getString(R.styleable.NumberPicker_np_formatter));
         mFadingEdgeEnabled = attributes.getBoolean(R.styleable.NumberPicker_np_fadingEdgeEnabled,
-            mFadingEdgeEnabled);
+                mFadingEdgeEnabled);
         mFadingEdgeStrength = attributes.getFloat(R.styleable.NumberPicker_np_fadingEdgeStrength,
-            mFadingEdgeStrength);
+                mFadingEdgeStrength);
         mScrollerEnabled = attributes.getBoolean(R.styleable.NumberPicker_np_scrollerEnabled,
-            mScrollerEnabled);
+                mScrollerEnabled);
         mWheelItemCount = attributes.getInt(R.styleable.NumberPicker_np_wheelItemCount,
-            mWheelItemCount);
+                mWheelItemCount);
         mLineSpacingMultiplier = attributes.getFloat(
-            R.styleable.NumberPicker_np_lineSpacingMultiplier, mLineSpacingMultiplier);
+                R.styleable.NumberPicker_np_lineSpacingMultiplier, mLineSpacingMultiplier);
         mMaxFlingVelocityCoefficient = attributes.getInt(
-            R.styleable.NumberPicker_np_maxFlingVelocityCoefficient,
-            mMaxFlingVelocityCoefficient);
+                R.styleable.NumberPicker_np_maxFlingVelocityCoefficient,
+                mMaxFlingVelocityCoefficient);
         mHideWheelUntilFocused = attributes.getBoolean(
-            R.styleable.NumberPicker_np_hideWheelUntilFocused, false);
+                R.styleable.NumberPicker_np_hideWheelUntilFocused, false);
         mAccessibilityDescriptionEnabled = attributes.getBoolean(
-            R.styleable.NumberPicker_np_accessibilityDescriptionEnabled, true);
+                R.styleable.NumberPicker_np_accessibilityDescriptionEnabled, true);
         mItemSpacing = attributes.getDimensionPixelSize(
-            R.styleable.NumberPicker_np_itemSpacing, 0);
-
+                R.styleable.NumberPicker_np_itemSpacing, 0);
         // By default LinearLayout that we extend is not drawn. This is
         // its draw() method is not called but dispatchDraw() is called
         // directly (see ViewGroup.drawChild()). However, this class uses
@@ -824,7 +823,7 @@ public class NumberPicker extends LinearLayout {
         setWillNotDraw(false);
 
         LayoutInflater inflater = (LayoutInflater) context.getSystemService(
-            Context.LAYOUT_INFLATER_SERVICE);
+                Context.LAYOUT_INFLATER_SERVICE);
         inflater.inflate(R.layout.number_picker_material, this, true);
 
         // input text
@@ -855,7 +854,7 @@ public class NumberPicker extends LinearLayout {
         setWheelItemCount(mWheelItemCount);
 
         mWrapSelectorWheel = attributes.getBoolean(R.styleable.NumberPicker_np_wrapSelectorWheel,
-            mWrapSelectorWheel);
+                mWrapSelectorWheel);
         setWrapSelectorWheel(mWrapSelectorWheel);
 
         if (width != SIZE_UNSPECIFIED && height != SIZE_UNSPECIFIED) {
@@ -876,7 +875,7 @@ public class NumberPicker extends LinearLayout {
         mTouchSlop = mViewConfiguration.getScaledTouchSlop();
         mMinimumFlingVelocity = mViewConfiguration.getScaledMinimumFlingVelocity();
         mMaximumFlingVelocity = mViewConfiguration.getScaledMaximumFlingVelocity()
-            / mMaxFlingVelocityCoefficient;
+                / mMaxFlingVelocityCoefficient;
 
         // create the fling and adjust scrollers
         mFlingScroller = new Scroller(context, null, true);
@@ -941,9 +940,9 @@ public class NumberPicker extends LinearLayout {
         super.onMeasure(newWidthMeasureSpec, newHeightMeasureSpec);
         // Flag if we are measured with width or height less than the respective min.
         final int widthSize = resolveSizeAndStateRespectingMinSize(mMinWidth, getMeasuredWidth(),
-            widthMeasureSpec);
+                widthMeasureSpec);
         final int heightSize = resolveSizeAndStateRespectingMinSize(mMinHeight, getMeasuredHeight(),
-            heightMeasureSpec);
+                heightMeasureSpec);
         setMeasuredDimension(widthSize, heightSize);
     }
 
@@ -1020,7 +1019,7 @@ public class NumberPicker extends LinearLayout {
                 mAdjustScroller.forceFinished(true);
                 onScrollerFinished(mAdjustScroller);
             } else if (mLastDownEventX >= mLeftDividerLeft
-                && mLastDownEventX <= mRightDividerRight) {
+                    && mLastDownEventX <= mRightDividerRight) {
                 if (mOnClickListener != null) {
                     mOnClickListener.onClick(this);
                 }
@@ -1039,7 +1038,7 @@ public class NumberPicker extends LinearLayout {
                 mFlingScroller.forceFinished(true);
                 mAdjustScroller.forceFinished(true);
             } else if (mLastDownEventY >= mTopDividerTop
-                && mLastDownEventY <= mBottomDividerBottom) {
+                    && mLastDownEventY <= mBottomDividerBottom) {
                 if (mOnClickListener != null) {
                     mOnClickListener.onClick(this);
                 }
@@ -1112,7 +1111,7 @@ public class NumberPicker extends LinearLayout {
                         int deltaMoveX = (int) Math.abs(eventX - mLastDownEventX);
                         if (deltaMoveX <= mTouchSlop) {
                             int selectorIndexOffset = (eventX / mSelectorElementSize)
-                                - mWheelMiddleItemIndex;
+                                    - mWheelMiddleItemIndex;
                             if (selectorIndexOffset > 0) {
                                 changeValueByOne(true);
                             } else if (selectorIndexOffset < 0) {
@@ -1135,7 +1134,7 @@ public class NumberPicker extends LinearLayout {
                         int deltaMoveY = (int) Math.abs(eventY - mLastDownEventY);
                         if (deltaMoveY <= mTouchSlop) {
                             int selectorIndexOffset = (eventY / mSelectorElementSize)
-                                - mWheelMiddleItemIndex;
+                                    - mWheelMiddleItemIndex;
                             if (selectorIndexOffset > 0) {
                                 changeValueByOne(true);
                             } else if (selectorIndexOffset < 0) {
@@ -1182,7 +1181,7 @@ public class NumberPicker extends LinearLayout {
                 switch (event.getAction()) {
                     case KeyEvent.ACTION_DOWN:
                         if (mWrapSelectorWheel || ((keyCode == KeyEvent.KEYCODE_DPAD_DOWN)
-                            ? getValue() < getMaxValue() : getValue() > getMinValue())) {
+                                ? getValue() < getMaxValue() : getValue() > getMinValue())) {
                             requestFocus();
                             mLastHandledDownDpadKeyCode = keyCode;
                             removeAllCallbacks();
@@ -1268,23 +1267,23 @@ public class NumberPicker extends LinearLayout {
         if (isHorizontalMode()) {
             if (isAscendingOrder()) {
                 if (!mWrapSelectorWheel && x > 0
-                    && selectorIndices[mWheelMiddleItemIndex] <= mMinValue) {
+                        && selectorIndices[mWheelMiddleItemIndex] <= mMinValue) {
                     mCurrentScrollOffset = mInitialScrollOffset;
                     return;
                 }
                 if (!mWrapSelectorWheel && x < 0
-                    && selectorIndices[mWheelMiddleItemIndex] >= mMaxValue) {
+                        && selectorIndices[mWheelMiddleItemIndex] >= mMaxValue) {
                     mCurrentScrollOffset = mInitialScrollOffset;
                     return;
                 }
             } else {
                 if (!mWrapSelectorWheel && x > 0
-                    && selectorIndices[mWheelMiddleItemIndex] >= mMaxValue) {
+                        && selectorIndices[mWheelMiddleItemIndex] >= mMaxValue) {
                     mCurrentScrollOffset = mInitialScrollOffset;
                     return;
                 }
                 if (!mWrapSelectorWheel && x < 0
-                    && selectorIndices[mWheelMiddleItemIndex] <= mMinValue) {
+                        && selectorIndices[mWheelMiddleItemIndex] <= mMinValue) {
                     mCurrentScrollOffset = mInitialScrollOffset;
                     return;
                 }
@@ -1294,23 +1293,23 @@ public class NumberPicker extends LinearLayout {
         } else {
             if (isAscendingOrder()) {
                 if (!mWrapSelectorWheel && y > 0
-                    && selectorIndices[mWheelMiddleItemIndex] <= mMinValue) {
+                        && selectorIndices[mWheelMiddleItemIndex] <= mMinValue) {
                     mCurrentScrollOffset = mInitialScrollOffset;
                     return;
                 }
                 if (!mWrapSelectorWheel && y < 0
-                    && selectorIndices[mWheelMiddleItemIndex] >= mMaxValue) {
+                        && selectorIndices[mWheelMiddleItemIndex] >= mMaxValue) {
                     mCurrentScrollOffset = mInitialScrollOffset;
                     return;
                 }
             } else {
                 if (!mWrapSelectorWheel && y > 0
-                    && selectorIndices[mWheelMiddleItemIndex] >= mMaxValue) {
+                        && selectorIndices[mWheelMiddleItemIndex] >= mMaxValue) {
                     mCurrentScrollOffset = mInitialScrollOffset;
                     return;
                 }
                 if (!mWrapSelectorWheel && y < 0
-                    && selectorIndices[mWheelMiddleItemIndex] <= mMinValue) {
+                        && selectorIndices[mWheelMiddleItemIndex] <= mMinValue) {
                     mCurrentScrollOffset = mInitialScrollOffset;
                     return;
                 }
@@ -1696,7 +1695,7 @@ public class NumberPicker extends LinearLayout {
         if (mDisplayedValues != null) {
             // Allow text entry rather than strictly numeric entry.
             mSelectedText.setRawInputType(InputType.TYPE_TEXT_FLAG_MULTI_LINE
-                | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
+                    | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
         } else {
             mSelectedText.setRawInputType(InputType.TYPE_CLASS_NUMBER);
         }
@@ -1740,7 +1739,7 @@ public class NumberPicker extends LinearLayout {
     protected void drawableStateChanged() {
         super.drawableStateChanged();
         if (mDividerDrawable != null && mDividerDrawable.isStateful()
-            && mDividerDrawable.setState(getDrawableState())) {
+                && mDividerDrawable.setState(getDrawableState())) {
             invalidateDrawable(mDividerDrawable);
         }
     }
@@ -1795,7 +1794,7 @@ public class NumberPicker extends LinearLayout {
             }
 
             int selectorIndex = selectorIndices[isAscendingOrder()
-                ? i : selectorIndices.length - i - 1];
+                    ? i : selectorIndices.length - i - 1];
             String scrollSelectorValue = mSelectorIndexToStringCache.get(selectorIndex);
             if (scrollSelectorValue == null) {
                 continue;
@@ -1806,7 +1805,7 @@ public class NumberPicker extends LinearLayout {
             // IME he may see a dimmed version of the old value intermixed
             // with the new one.
             if ((showSelectorWheel && i != mWheelMiddleItemIndex)
-                || (i == mWheelMiddleItemIndex && mSelectedText.getVisibility() != VISIBLE)) {
+                    || (i == mWheelMiddleItemIndex && mSelectedText.getVisibility() != VISIBLE)) {
                 float textY = y;
                 if (!isHorizontalMode()) {
                     textY += getPaintCenterY(mSelectorWheelPaint.getFontMetrics());
@@ -1889,10 +1888,10 @@ public class NumberPicker extends LinearLayout {
                 final int bottomOfUnderlineDivider = mBottomDividerBottom;
                 final int topOfUnderlineDivider = bottomOfUnderlineDivider - mDividerThickness;
                 mDividerDrawable.setBounds(
-                    left,
-                    topOfUnderlineDivider ,
-                    right,
-                    bottomOfUnderlineDivider
+                        left,
+                        topOfUnderlineDivider,
+                        right,
+                        bottomOfUnderlineDivider
                 );
                 mDividerDrawable.draw(canvas);
                 break;
@@ -1914,26 +1913,26 @@ public class NumberPicker extends LinearLayout {
                 // draw the top divider
                 final int topOfTopDivider = mTopDividerTop;
                 final int bottomOfTopDivider = topOfTopDivider + mDividerThickness;
-                mDividerDrawable.setBounds(left, topOfTopDivider, right, bottomOfTopDivider );
+                mDividerDrawable.setBounds(left, topOfTopDivider, right, bottomOfTopDivider);
                 mDividerDrawable.draw(canvas);
                 // draw the bottom divider
                 final int bottomOfBottomDivider = mBottomDividerBottom;
                 final int topOfBottomDivider = bottomOfBottomDivider - mDividerThickness;
                 mDividerDrawable.setBounds(
-                    left,
-                    topOfBottomDivider,
-                    right,
-                    bottomOfBottomDivider);
+                        left,
+                        topOfBottomDivider,
+                        right,
+                        bottomOfBottomDivider);
                 mDividerDrawable.draw(canvas);
                 break;
             case UNDERLINE:
                 final int bottomOfUnderlineDivider = mBottomDividerBottom;
                 final int topOfUnderlineDivider = bottomOfUnderlineDivider - mDividerThickness;
                 mDividerDrawable.setBounds(
-                    left,
-                    topOfUnderlineDivider,
-                    right,
-                    bottomOfUnderlineDivider
+                        left,
+                        topOfUnderlineDivider,
+                        right,
+                        bottomOfUnderlineDivider
                 );
                 mDividerDrawable.draw(canvas);
                 break;
@@ -1944,7 +1943,7 @@ public class NumberPicker extends LinearLayout {
         if (text.contains("\n")) {
             final String[] lines = text.split("\n");
             final float height = Math.abs(paint.descent() + paint.ascent())
-                * mLineSpacingMultiplier;
+                    * mLineSpacingMultiplier;
             final float diff = (lines.length - 1) * height / 2;
             y -= diff;
             for (String line : lines) {
@@ -2447,25 +2446,25 @@ public class NumberPicker extends LinearLayout {
      * The numbers accepted by the input text's {@link Filter}
      */
     private static final char[] DIGIT_CHARACTERS = new char[]{
-        // Latin digits are the common case
-        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-        // Arabic-Indic
-        '\u0660', '\u0661', '\u0662', '\u0663', '\u0664',
-        '\u0665', '\u0666', '\u0667', '\u0668', '\u0669',
-        // Extended Arabic-Indic
-        '\u06f0', '\u06f1', '\u06f2', '\u06f3', '\u06f4',
-        '\u06f5', '\u06f6', '\u06f7', '\u06f8', '\u06f9',
-        // Hindi and Marathi (Devanagari script)
-        '\u0966', '\u0967', '\u0968', '\u0969', '\u096a',
-        '\u096b', '\u096c', '\u096d', '\u096e', '\u096f',
-        // Bengali
-        '\u09e6', '\u09e7', '\u09e8', '\u09e9', '\u09ea',
-        '\u09eb', '\u09ec', '\u09ed', '\u09ee', '\u09ef',
-        // Kannada
-        '\u0ce6', '\u0ce7', '\u0ce8', '\u0ce9', '\u0cea',
-        '\u0ceb', '\u0cec', '\u0ced', '\u0cee', '\u0cef',
-        // Negative
-        '-'
+            // Latin digits are the common case
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            // Arabic-Indic
+            '\u0660', '\u0661', '\u0662', '\u0663', '\u0664',
+            '\u0665', '\u0666', '\u0667', '\u0668', '\u0669',
+            // Extended Arabic-Indic
+            '\u06f0', '\u06f1', '\u06f2', '\u06f3', '\u06f4',
+            '\u06f5', '\u06f6', '\u06f7', '\u06f8', '\u06f9',
+            // Hindi and Marathi (Devanagari script)
+            '\u0966', '\u0967', '\u0968', '\u0969', '\u096a',
+            '\u096b', '\u096c', '\u096d', '\u096e', '\u096f',
+            // Bengali
+            '\u09e6', '\u09e7', '\u09e8', '\u09e9', '\u09ea',
+            '\u09eb', '\u09ec', '\u09ed', '\u09ee', '\u09ef',
+            // Kannada
+            '\u0ce6', '\u0ce7', '\u0ce8', '\u0ce9', '\u0cea',
+            '\u0ceb', '\u0cec', '\u0ced', '\u0cee', '\u0cef',
+            // Negative
+            '-'
     };
 
     /**
@@ -2500,7 +2499,7 @@ public class NumberPicker extends LinearLayout {
                 }
 
                 String result = String.valueOf(dest.subSequence(0, dstart)) + filtered
-                    + dest.subSequence(dend, dest.length());
+                        + dest.subSequence(dend, dest.length());
 
                 if ("".equals(result)) {
                     return result;
@@ -2636,7 +2635,7 @@ public class NumberPicker extends LinearLayout {
 
     private float spToPx(float sp) {
         return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, sp,
-            getResources().getDisplayMetrics());
+                getResources().getDisplayMetrics());
     }
 
     private float pxToSp(float px) {
@@ -2880,7 +2879,7 @@ public class NumberPicker extends LinearLayout {
     public void setMaxFlingVelocityCoefficient(int coefficient) {
         mMaxFlingVelocityCoefficient = coefficient;
         mMaximumFlingVelocity = mViewConfiguration.getScaledMaximumFlingVelocity()
-            / mMaxFlingVelocityCoefficient;
+                / mMaxFlingVelocityCoefficient;
     }
 
     public void setItemSpacing(int itemSpacing) {

--- a/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
+++ b/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
@@ -1814,7 +1814,7 @@ public class NumberPicker extends LinearLayout {
                 int xOffset = 0;
                 int yOffset = 0;
 
-                if (i != mWheelMiddleItemIndex) {
+                if (i != mWheelMiddleItemIndex && mItemSpacing != 0) {
                     if (isHorizontalMode()) {
                         if (i > mWheelMiddleItemIndex) {
                             xOffset = mItemSpacing;

--- a/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
+++ b/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
@@ -2330,7 +2330,7 @@ public class NumberPicker extends LinearLayout {
          * number.
          */
         String text = (mDisplayedValues == null) ? formatNumber(mValue)
-            : mDisplayedValues[mValue - mMinValue];
+                : mDisplayedValues[mValue - mMinValue];
         if (TextUtils.isEmpty(text)) {
             return;
         }
@@ -2524,7 +2524,7 @@ public class NumberPicker extends LinearLayout {
                     return "";
                 }
                 String result = String.valueOf(dest.subSequence(0, dstart)) + filtered
-                    + dest.subSequence(dend, dest.length());
+                        + dest.subSequence(dend, dest.length());
                 String str = String.valueOf(result).toLowerCase();
                 for (String val : mDisplayedValues) {
                     String valLowerCase = val.toLowerCase();

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -56,5 +56,6 @@
         <attr name="np_value" format="integer" />
         <attr name="np_wheelItemCount" format="integer" />
         <attr name="np_wrapSelectorWheel" format="boolean" />
+        <attr name="np_itemSpacing" format="dimension" />
     </declare-styleable>
 </resources>

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -20,6 +20,7 @@
         <attr name="np_fadingEdgeStrength" format="float" />
         <attr name="np_formatter" format="string" />
         <attr name="np_hideWheelUntilFocused" format="boolean" />
+        <attr name="np_itemSpacing" format="dimension" />
         <attr name="np_lineSpacingMultiplier" format="float" />
         <attr name="np_max" format="integer" />
         <attr name="np_maxFlingVelocityCoefficient" format="integer" />
@@ -56,6 +57,5 @@
         <attr name="np_value" format="integer" />
         <attr name="np_wheelItemCount" format="integer" />
         <attr name="np_wrapSelectorWheel" format="boolean" />
-        <attr name="np_itemSpacing" format="dimension" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
Adds a the `np_itemSpacing` attr to control the amount space between items. This value can be negative or positive. A positive value moves the items farther apart and a negative value  moves the items closer together. The item spacing can be controlled either by using the `np_itemSpacing` attr or calling the `setItemSpacing` function.

This is achieved by adding an x or y offset based on the orientation of the picker to the values passed to the `drawText` functions. For items before the middle item the offset is negative and for items after the middle item the offset is positive.

![Screenshot_1606915873](https://user-images.githubusercontent.com/17283517/100891226-0e4ba580-3487-11eb-8e0a-08a31097ef3e.png)
 