### PR TITLE
Fix wrap wheel bug when setting min value

### DIFF
--- a/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
+++ b/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
@@ -1627,7 +1627,8 @@ public class NumberPicker extends LinearLayout {
         if (mMinValue > mValue) {
             mValue = mMinValue;
         }
-        setWrapSelectorWheel(isWrappingAllowed() && mWrapSelectorWheelPreferred);
+
+        updateWrapSelectorWheel();
         initializeSelectorWheelIndices();
         updateInputTextView();
         tryComputeMaxWidth();

--- a/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
+++ b/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
@@ -1627,7 +1627,7 @@ public class NumberPicker extends LinearLayout {
         if (mMinValue > mValue) {
             mValue = mMinValue;
         }
-        setWrapSelectorWheel(isWrappingAllowed());
+        setWrapSelectorWheel(isWrappingAllowed() && mWrapSelectorWheelPreferred);
         initializeSelectorWheelIndices();
         updateInputTextView();
         tryComputeMaxWidth();


### PR DESCRIPTION
If `setMinValue` is called after `setWrapSelectorWheel` is called then the value value passed into `setWrapSelectorWheel` will be overridden with the value returned from `isWrappingAllowed()`

The fix is to && the return value of `isWrappingAllowed` with `mWrapSelectorWheelPreferred`, that way the users preferences is accounted for.  