### PR TITLE
Fixed on click scroll when selected text size and general text size are different

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: shawnlin

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 The android library that provides a simple and customizable NumberPicker.
 It's based on [android.widget.NumberPicker](https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/widget/NumberPicker.java).
 
-[![Platform](http://img.shields.io/badge/platform-android-brightgreen.svg?style=flat)](http://developer.android.com/index.html) [![Language](http://img.shields.io/badge/language-java-orange.svg?style=flat)](http://www.oracle.com/technetwork/java/javase/downloads/index.html) [![](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-NumberPicker-green.svg?style=true)](https://android-arsenal.com/details/1/3718) [![API](https://img.shields.io/badge/API-15%2B-blue.svg?style=flat)](https://android-arsenal.com/api?level=15) [![Download](https://api.bintray.com/packages/shawnlin013/maven/number-picker/images/download.svg)](https://bintray.com/shawnlin013/maven/number-picker/_latestVersion) [![CircleCI](https://circleci.com/gh/ShawnLin013/NumberPicker.svg?style=svg)](https://circleci.com/gh/ShawnLin013/NumberPicker)
+[![Platform](http://img.shields.io/badge/platform-android-brightgreen.svg?style=flat)](http://developer.android.com/index.html) [![Language](http://img.shields.io/badge/language-java-orange.svg?style=flat)](http://www.oracle.com/technetwork/java/javase/downloads/index.html) [![](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-NumberPicker-green.svg?style=true)](https://android-arsenal.com/details/1/3718) [![API](https://img.shields.io/badge/API-15%2B-blue.svg?style=flat)](https://android-arsenal.com/api?level=15) ![Maven Central](https://img.shields.io/maven-central/v/io.github.ShawnLin013/number-picker) [![CircleCI](https://circleci.com/gh/ShawnLin013/NumberPicker.svg?style=svg)](https://circleci.com/gh/ShawnLin013/NumberPicker)
+[![GitHub stars](https://img.shields.io/github/stars/ShawnLin013/NumberPicker)](https://github.com/ShawnLin013/NumberPicker/stargazers) [![GitHub forks](https://img.shields.io/github/forks/ShawnLin013/NumberPicker)](https://github.com/ShawnLin013/NumberPicker/network)
 
 <img src="https://github.com/ShawnLin013/NumberPicker/blob/master/screenshot/number-picker-theme.png">
 
@@ -138,7 +139,7 @@ add `xmlns:app="http://schemas.android.com/apk/res-auto"`
 
 ### Attributes
 
-|attribute name|attribute description|defalut|
+|attribute name|attribute description|default|
 |:---:|:---:|:---:|
 |np_width|The width of this widget.|
 |np_height|The height of this widget.|
@@ -183,12 +184,12 @@ Add the dependency in your `build.gradle`
 ```gradle
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }
 
 dependencies {
-    implementation 'com.shawnlin:number-picker:2.4.12'
+    implementation 'io.github.ShawnLin013:number-picker:2.4.13'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.2'
@@ -16,7 +16,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.2'
-        classpath "guru.stefma.bintrayrelease:bintrayrelease:1.1.2"
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.28.0'
     }
 }
 
@@ -17,6 +15,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url "https://jitpack.io" }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,27 @@
-VERSION_CODE=20
-VERSION_NAME=2.4.12
-
-GROUP_ID=com.shawnlin
-ARTIFACT_ID=number-picker
-
-POM_DESCRIPTION=The android library that provides a simple and customizable NumberPicker.
-POM_URL=https://github.com/ShawnLin013/NumberPicker
-POM_LICENSE_NAME=MIT
-POM_LICENSE_URL=https://opensource.org/licenses/MIT
-POM_LICENSE_DIST=repo
-POM_DEVELOPER_ID=shawnlin013
 android.useAndroidX=true
 android.enableJetifier=true
 android.debug.obsoleteApi=true
+
+VERSION_CODE=21
+VERSION_NAME=2.4.13
+
+GROUP=io.github.ShawnLin013
+POM_ARTIFACT_ID=number-picker
+
+POM_NAME=Number Picker
+POM_PACKAGING=aar
+POM_DESCRIPTION=The android library that provides a simple and customizable NumberPicker.
+POM_INCEPTION_YEAR=2021
+POM_URL=https://github.com/ShawnLin013/NumberPicker
+
+POM_LICENCE_NAME=MIT
+POM_LICENCE_URL=https://opensource.org/licenses/MIT
+POM_LICENCE_DIST=repo
+
+POM_SCM_URL=https://github.com/ShawnLin013/NumberPicker
+POM_SCM_CONNECTION=scm:git@github.com:ShawnLin013/NumberPicker.git
+POM_SCM_DEV_CONNECTION=scm:git@github.com:ShawnLin013/NumberPicker.git
+
+POM_DEVELOPER_ID=ShawnLin013
+POM_DEVELOPER_NAME=Shawn Lin
+POM_DEVELOPER_URL=https://github.com/ShawnLin013/NumberPicker

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Sat Jun 13 03:38:47 CST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,34 +1,41 @@
-apply plugin: 'com.android.library'
-apply plugin: "guru.stefma.bintrayrelease"
+plugins {
+    id 'com.vanniktech.maven.publish'
+    id 'com.android.library'
+}
 
 android {
-    compileSdkVersion 30
-
     defaultConfig {
+        compileSdk 34
         minSdkVersion 15
-        targetSdkVersion 30
+        targetSdkVersion 34
         versionCode VERSION_CODE as int
         versionName VERSION_NAME
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    namespace 'com.shawnlin.numberpicker'
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
 }
 
-version = VERSION_NAME
-group = GROUP_ID
-androidArtifact {
-    artifactId = ARTIFACT_ID
-    license {
-        name = POM_LICENSE_NAME
-        url = POM_LICENSE_URL
-        distribution = POM_LICENSE_DIST
+publishing {
+    publications {
+        myMaven(MavenPublication) {
+            groupId GROUP
+            artifactId POM_ARTIFACT_ID
+            version VERSION_NAME
+            artifact("$buildDir/outputs/aar/library-release.aar")
+        }
     }
 }
-publish {
-    userOrg = POM_DEVELOPER_ID
-    desc = POM_DESCRIPTION
-    website = POM_URL
+
+tasks.named("publishMyMavenPublicationToMavenLocal") {
+    dependsOn tasks.named("bundleReleaseAar")
 }

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,3 +1,1 @@
-<manifest package="com.shawnlin.numberpicker"
-    xmlns:android="http://schemas.android.com/apk/res/android">
-</manifest>
+<manifest />

--- a/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
+++ b/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
@@ -2073,9 +2073,6 @@ public class NumberPicker extends LinearLayout {
      * @param notifyChange Whether to notify if the current value changed.
      */
     private void setValueInternal(int current, boolean notifyChange) {
-        if (mValue == current) {
-            return;
-        }
         // Wrap around the values if we go past the start or end
         if (mWrapSelectorWheel) {
             current = getWrappedSelectorIndex(current);
@@ -2083,6 +2080,11 @@ public class NumberPicker extends LinearLayout {
             current = Math.max(current, mMinValue);
             current = Math.min(current, mMaxValue);
         }
+
+        if (mValue == current) {
+            return;
+        }
+
         int previous = mValue;
         mValue = current;
         // If we're flinging, we'll update the text view at the end when it becomes visible

--- a/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
+++ b/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
@@ -1110,11 +1110,9 @@ public class NumberPicker extends LinearLayout {
                         int eventX = (int) event.getX();
                         int deltaMoveX = (int) Math.abs(eventX - mLastDownEventX);
                         if (deltaMoveX <= mTouchSlop) {
-                            int selectorIndexOffset = (eventX / mSelectorElementSize)
-                                    - mWheelMiddleItemIndex;
-                            if (selectorIndexOffset > 0) {
+                            if (eventX > mRightDividerRight) {
                                 changeValueByOne(true);
-                            } else if (selectorIndexOffset < 0) {
+                            } else if (eventX < mLeftDividerLeft) {
                                 changeValueByOne(false);
                             } else {
                                 ensureScrollWheelAdjusted();
@@ -1133,11 +1131,9 @@ public class NumberPicker extends LinearLayout {
                         int eventY = (int) event.getY();
                         int deltaMoveY = (int) Math.abs(eventY - mLastDownEventY);
                         if (deltaMoveY <= mTouchSlop) {
-                            int selectorIndexOffset = (eventY / mSelectorElementSize)
-                                    - mWheelMiddleItemIndex;
-                            if (selectorIndexOffset > 0) {
+                            if (eventY > mBottomDividerBottom) {
                                 changeValueByOne(true);
-                            } else if (selectorIndexOffset < 0) {
+                            } else if (eventY < mTopDividerTop) {
                                 changeValueByOne(false);
                             } else {
                                 ensureScrollWheelAdjusted();

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,12 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
-
     defaultConfig {
         applicationId "com.shawnlin.numberpicker.sample"
+        compileSdk 34
         minSdkVersion 15
-        targetSdkVersion 30
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
     }
@@ -16,11 +15,13 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    namespace 'com.shawnlin.numberpicker.sample'
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.3.0-alpha03'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'com.google.android.material:material:1.4.0-beta01'
     implementation project(':library')
 }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.shawnlin.numberpicker.sample"
+<manifest
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
@@ -10,6 +10,7 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:label="@string/app_name"
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme.NoActionBar">


### PR DESCRIPTION
Hi,

Thanks for this library. It has been a great help. I have however had 1 small problem when using the following settings:
np_selectedTextSize = 70sp
np_textSize = 30sp
np_wheelItemCount = 7
np_orientation = horizontal

Tapping the selected number causes the picker to decrement and tapping the first number to the right of the selected number causes no scroll.

I believe the cause is the line
`int selectorIndexOffset = (eventX / mSelectorElementSize) - mWheelMiddleItemIndex;`

If I understand the code correctly, it is assuming all elements are a similar size as it is using the size of the selector to determine which index has been tapped. If the selector element is bigger due to the the selector text size being bigger, the result of this will not be accurate.
