### PR TITLE
Add ability to use drawables as a divider

### DIFF
--- a/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
+++ b/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
@@ -77,12 +77,18 @@ public class NumberPicker extends LinearLayout {
     public static final int LEFT = 2;
 
     @Retention(SOURCE)
-    @IntDef({SIDE_LINES, UNDERLINE})
+    @IntDef({SIDE_LINES, UNDERLINE, DRAWABLE_AS_DIVIDER})
     public @interface DividerType {
     }
 
     public static final int SIDE_LINES = 0;
     public static final int UNDERLINE = 1;
+    public static final int DRAWABLE_AS_DIVIDER = 2;
+
+    /**
+     * The default drawable resource ID for drawable divider.
+     */
+    public static final int DEFAULT_DRAWABLE_DIVIDER_RES = 0;
 
     /**
      * The default update interval during long press.
@@ -128,6 +134,11 @@ public class NumberPicker extends LinearLayout {
      * The default color of divider.
      */
     private static final int DEFAULT_DIVIDER_COLOR = 0xFF000000;
+
+    /**
+     * The default alpha value for the drawable divider.
+     */
+    private static final int DEFAULT_DIVIDER_DRAWABLE_ALPHA_VALUE = 100;
 
     /**
      * The default max value of this widget.
@@ -304,6 +315,16 @@ public class NumberPicker extends LinearLayout {
      * The color of the text.
      */
     private int mTextColor = DEFAULT_TEXT_COLOR;
+
+    /**
+     * The drawable divider resource.
+     */
+    private int mDividerResource = DEFAULT_DRAWABLE_DIVIDER_RES;
+
+    /**
+     * The alpha value for the drawable divider
+     */
+    private int mDividerDrawableAlphaValue = DEFAULT_DIVIDER_DRAWABLE_ALPHA_VALUE;
 
     /**
      * The size of the text.
@@ -1896,6 +1917,17 @@ public class NumberPicker extends LinearLayout {
                 );
                 mDividerDrawable.draw(canvas);
                 break;
+            case DRAWABLE_AS_DIVIDER:
+                final int drawableLeft = (getWidth() - mDividerLength)/ 2;
+                final int drawableTop = (getHeight() - mDividerThickness)/2;
+                final int drawableRight = (getWidth() + mDividerLength)/ 2;
+                final int drawableBottom = (getHeight() + mDividerThickness)/2;
+
+                mDividerDrawable = getResources().getDrawable(mDividerResource);
+                mDividerDrawable.setBounds(drawableLeft, drawableTop, drawableRight, drawableBottom);
+                mDividerDrawable.setAlpha(mDividerDrawableAlphaValue);
+                mDividerDrawable.draw(canvas);
+                break;
         }
     }
 
@@ -1935,6 +1967,16 @@ public class NumberPicker extends LinearLayout {
                         right,
                         bottomOfUnderlineDivider
                 );
+                mDividerDrawable.draw(canvas);
+                break;
+            case DRAWABLE_AS_DIVIDER:
+                final int drawableLeft = (getWidth() - mDividerLength) / 2;
+                final int drawableTop = (getHeight() - mDividerThickness) / 2;
+                final int drawableRight = (getWidth() + mDividerLength) / 2;
+                final int drawableBottom = (getHeight() + mDividerThickness) / 2;
+                mDividerDrawable = getResources().getDrawable(mDividerResource);
+                mDividerDrawable.setBounds(drawableLeft, drawableTop, drawableRight, drawableBottom);
+                mDividerDrawable.setAlpha(mDividerDrawableAlphaValue);
                 mDividerDrawable.draw(canvas);
                 break;
         }
@@ -2677,6 +2719,11 @@ public class NumberPicker extends LinearLayout {
     public void setDividerColor(@ColorInt int color) {
         mDividerColor = color;
         mDividerDrawable = new ColorDrawable(color);
+    }
+
+    public void setDividerDrawableResource(int drawableResourceId)
+    {
+        mDividerResource = drawableResourceId;
     }
 
     public void setDividerColorResource(@ColorRes int colorId) {

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -11,6 +11,7 @@
         <attr name="np_dividerType" format="enum">
             <enum name="side_lines" value="0" />
             <enum name="underline" value="1" />
+            <enum name="drawable_as_divider" value="2" />
         </attr>
         <attr name="np_dividerColor" format="color" />
         <attr name="np_dividerDistance" format="dimension" />

--- a/sample/src/main/java/com/shawnlin/numberpicker/sample/MainActivity.java
+++ b/sample/src/main/java/com/shawnlin/numberpicker/sample/MainActivity.java
@@ -25,6 +25,9 @@ public class MainActivity extends AppCompatActivity {
         setSupportActionBar(toolbar);
 
         final NumberPicker numberPicker = findViewById(R.id.number_picker);
+        final NumberPicker numberPickerDrawableDividerVertical = findViewById(R.id.number_picker_drawable_divider_vertical);
+        final NumberPicker numberPickerDrawableDividerHorizontal = findViewById(R.id.number_picker_drawable_divider_horizontal);
+
 
         // Set divider color
         numberPicker.setDividerColor(ContextCompat.getColor(this, R.color.colorPrimary));
@@ -112,6 +115,10 @@ public class MainActivity extends AppCompatActivity {
                 }
             }
         });
+
+        // Set drawable as divider
+        numberPickerDrawableDividerVertical.setDividerDrawableResource(R.drawable.blue_rectangle);
+        numberPickerDrawableDividerHorizontal.setDividerDrawableResource(R.drawable.accent_rectangle);
     }
 
 }

--- a/sample/src/main/res/drawable/accent_rectangle.xml
+++ b/sample/src/main/res/drawable/accent_rectangle.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/colorAccent"/>
+    <corners android:radius="16dp"/>
+</shape>

--- a/sample/src/main/res/drawable/blue_rectangle.xml
+++ b/sample/src/main/res/drawable/blue_rectangle.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+        <solid android:color="@color/colorPrimary"/>
+        <corners android:radius="16dp"/>
+</shape>

--- a/sample/src/main/res/layout/content_main.xml
+++ b/sample/src/main/res/layout/content_main.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -7,9 +8,11 @@
     android:gravity="center"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_horizontal_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingStart="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_vertical_margin"
+    android:paddingEnd="@dimen/activity_vertical_margin"
     app:layout_behavior="@string/appbar_scrolling_view_behavior"
     tools:context="com.shawnlin.numberpicker.sample.MainActivity"
     tools:showIn="@layout/activity_main">
@@ -17,17 +20,44 @@
     <com.shawnlin.numberpicker.NumberPicker
         android:id="@+id/number_picker"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        android:layout_height="200dp"
+        android:layout_marginStart="50dp"
+        android:layout_marginLeft="50dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"/>
+
+    <com.shawnlin.numberpicker.NumberPicker
+        android:id="@+id/number_picker_drawable_divider_vertical"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        app:np_selectedTextColor="@color/colorAccent"
+        app:np_selectedTextSize="@dimen/selected_text_size"
+        app:np_selectedTypeface="@string/roboto_light"
+        app:np_textColor="@color/colorAccent"
+        app:np_dividerThickness="50dp"
+        app:np_dividerLength="60dp"
+        app:np_orientation="vertical"
+        app:np_dividerType="drawable_as_divider"
+        android:layout_marginRight="50dp"
+        android:layout_marginEnd="50dp"
+        app:layout_constraintTop_toTopOf="@+id/number_picker"
+        app:layout_constraintBottom_toBottomOf="@+id/number_picker"
+        app:layout_constraintEnd_toEndOf="parent"/>
 
     <com.shawnlin.numberpicker.NumberPicker
         android:id="@+id/horizontal_number_picker"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="60dp"
-        app:np_width="180dp"
-        app:np_height="64dp"
+        android:layout_marginTop="40dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/number_picker"
         app:np_accessibilityDescriptionEnabled="true"
         app:np_dividerColor="@color/colorAccent"
+        app:np_dividerType="underline"
+        app:np_fadingEdgeEnabled="false"
+        app:np_height="64dp"
         app:np_max="10"
         app:np_min="0"
         app:np_order="descending"
@@ -38,8 +68,32 @@
         app:np_textColor="@color/colorAccent"
         app:np_textSize="@dimen/text_size"
         app:np_typeface="@string/roboto_light"
-        app:np_fadingEdgeEnabled="false"
-        app:np_wrapSelectorWheel="true"
-        app:np_dividerType="underline" />
+        app:np_width="180dp"
+        app:np_wrapSelectorWheel="true" />
 
-</LinearLayout>
+    <com.shawnlin.numberpicker.NumberPicker
+        android:id="@+id/number_picker_drawable_divider_horizontal"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="30dp"
+        app:np_orientation="horizontal"
+        app:np_dividerThickness="40dp"
+        app:np_dividerLength="70dp"
+        app:np_dividerType="drawable_as_divider"
+        app:np_height="64dp"
+        app:np_max="10"
+        app:np_min="0"
+        app:np_order="descending"
+        app:np_selectedTextColor="@color/colorPrimary"
+        app:np_selectedTextSize="@dimen/selected_text_size"
+        app:np_selectedTypeface="@string/roboto_light"
+        app:np_textColor="@color/colorPrimary"
+        app:np_textSize="@dimen/text_size"
+        app:np_typeface="@string/roboto_light"
+        app:np_width="180dp"
+        app:layout_constraintStart_toStartOf="@+id/horizontal_number_picker"
+        app:layout_constraintEnd_toEndOf="@+id/horizontal_number_picker"
+        app:layout_constraintTop_toBottomOf="@+id/horizontal_number_picker"/>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
It is only possible to use sidelines and underlines as a divider.
But sometimes there is a need to use a background.

![NumberPicker divider drawable](https://user-images.githubusercontent.com/8686389/125703071-8311a576-a0dd-4fec-aefb-ffa803477136.png)
