### PR TITLE
Gap size changing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ numberPicker.setMaxValue(59);
 numberPicker.setMinValue(0);
 numberPicker.setValue(3);
 
+//Set gap size
+numberPicker.setGapSize(50);
+
 // Using string values
 // IMPORTANT! setMinValue to 1 and call setDisplayedValues after setMinValue and setMaxValue
 String[] data = {"A", "B", "C", "D", "E", "F", "G", "H", "I"};
@@ -127,6 +130,7 @@ add `xmlns:app="http://schemas.android.com/apk/res-auto"`
     app:np_height="180dp"
     app:np_dividerColor="@color/colorPrimary"
     app:np_formatter="@string/number_picker_formatter"
+    app:np_gapSize="50"
     app:np_max="59"
     app:np_min="0"
     app:np_selectedTextColor="@color/colorPrimary"
@@ -155,6 +159,7 @@ add `xmlns:app="http://schemas.android.com/apk/res-auto"`
 |np_hideWheelUntilFocused|Flag whether the selector wheel should hidden until the picker has focus.|
 |np_itemSpacing|Amount of space between items.|
 |np_lineSpacingMultiplier|The line spacing multiplier for the multiple lines.|
+|np_gapSize|The gap size of this widget.|
 |np_max|The max value of this widget.|
 |np_maxFlingVelocityCoefficient|The coefficient to adjust (divide) the max fling velocity.|
 |np_min|The min value of this widget.|

--- a/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
+++ b/library/src/main/java/com/shawnlin/numberpicker/NumberPicker.java
@@ -1,5 +1,7 @@
 package com.shawnlin.numberpicker;
 
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.TypedArray;
@@ -43,8 +45,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.Locale;
-
-import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 /**
  * A widget that enables the user to select a number from a predefined range.
@@ -173,6 +173,11 @@ public class NumberPicker extends LinearLayout {
      * The default line spacing multiplier of text.
      */
     private static final float DEFAULT_LINE_SPACING_MULTIPLIER = 1f;
+
+    /**
+     * The default gap size.
+     */
+    private static final int DEFAULT_GAP_SIZE = 0;
 
     /**
      * Use a custom NumberPicker formatting callback to use two-digit minutes
@@ -576,6 +581,11 @@ public class NumberPicker extends LinearLayout {
     private int mOrientation;
 
     /**
+     * The gap size between items
+     */
+    private int mGapSize;
+
+    /**
      * The order of this widget.
      */
     private int mOrder;
@@ -759,6 +769,8 @@ public class NumberPicker extends LinearLayout {
 
         mOrder = attributes.getInt(R.styleable.NumberPicker_np_order, ASCENDING);
         mOrientation = attributes.getInt(R.styleable.NumberPicker_np_orientation, VERTICAL);
+
+        mGapSize = attributes.getInt(R.styleable.NumberPicker_np_gapSize, DEFAULT_GAP_SIZE);
 
         final float width = attributes.getDimensionPixelSize(R.styleable.NumberPicker_np_width,
                 SIZE_UNSPECIFIED);
@@ -1671,6 +1683,24 @@ public class NumberPicker extends LinearLayout {
     }
 
     /**
+     * Sets the gap size of the picker.
+     *
+     * @param size The gap size.
+     */
+    public void setGapSize(int size) {
+        mGapSize = size;
+    }
+
+    /**
+     * Gets the gap size of the picker.
+     *
+     * @return The gap size.
+     */
+    public int getGapSize() {
+        return mGapSize;
+    }
+
+    /**
      * Gets the values to be displayed instead of string values.
      *
      * @return The displayed values.
@@ -2165,12 +2195,12 @@ public class NumberPicker extends LinearLayout {
         float textGapCount = selectorIndices.length;
         if (isHorizontalMode()) {
             float totalTextGapWidth = (getRight() - getLeft()) - totalTextSize;
-            mSelectorTextGapWidth = (int) (totalTextGapWidth / textGapCount);
+            mSelectorTextGapWidth = (int) (totalTextGapWidth / textGapCount) + mGapSize;
             mSelectorElementSize = (int) getMaxTextSize() + mSelectorTextGapWidth;
             mInitialScrollOffset = (int) (mSelectedTextCenterX - mSelectorElementSize * mWheelMiddleItemIndex);
         } else {
             float totalTextGapHeight = (getBottom() - getTop()) - totalTextSize;
-            mSelectorTextGapHeight = (int) (totalTextGapHeight / textGapCount);
+            mSelectorTextGapHeight = (int) (totalTextGapHeight / textGapCount) + mGapSize;
             mSelectorElementSize = (int) getMaxTextSize() + mSelectorTextGapHeight;
             mInitialScrollOffset = (int) (mSelectedTextCenterY - mSelectorElementSize * mWheelMiddleItemIndex);
         }

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -57,5 +57,6 @@
         <attr name="np_value" format="integer" />
         <attr name="np_wheelItemCount" format="integer" />
         <attr name="np_wrapSelectorWheel" format="boolean" />
+        <attr name="np_gapSize" format="integer"/>
     </declare-styleable>
 </resources>

--- a/sample/src/main/res/layout/content_main.xml
+++ b/sample/src/main/res/layout/content_main.xml
@@ -6,10 +6,10 @@
     android:layout_height="match_parent"
     android:gravity="center"
     android:orientation="vertical"
-    android:paddingBottom="@dimen/activity_vertical_margin"
     android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
     app:layout_behavior="@string/appbar_scrolling_view_behavior"
     tools:context="com.shawnlin.numberpicker.sample.MainActivity"
     tools:showIn="@layout/activity_main">
@@ -24,10 +24,12 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="60dp"
-        app:np_width="180dp"
-        app:np_height="64dp"
         app:np_accessibilityDescriptionEnabled="true"
         app:np_dividerColor="@color/colorAccent"
+        app:np_dividerType="underline"
+        app:np_fadingEdgeEnabled="false"
+        app:np_gapSize="50"
+        app:np_height="64dp"
         app:np_max="10"
         app:np_min="0"
         app:np_order="descending"
@@ -38,8 +40,6 @@
         app:np_textColor="@color/colorAccent"
         app:np_textSize="@dimen/text_size"
         app:np_typeface="@string/roboto_light"
-        app:np_fadingEdgeEnabled="false"
-        app:np_wrapSelectorWheel="true"
-        app:np_dividerType="underline" />
-
+        app:np_width="180dp"
+        app:np_wrapSelectorWheel="true" />
 </LinearLayout>


### PR DESCRIPTION
# Description

- Feature request #69 
- Added `np_gapSize` attribute for NumberPicker view. Using this attr you can change width/height between picker items

# Demo

Below in the screenshot you can see an example of using different  gap size

![Screenshot 2022-04-25 224338](https://user-images.githubusercontent.com/32297268/165162923-b55479e2-af46-4495-a018-bb7fe6774117.png)

First NumberPicker uses default gap size. View in the middle uses gap size -50. Last one uses gap size 50

# Type of change
 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code
- I have made corresponding changes to the documentation
- My changes generate no new warnings
